### PR TITLE
bump dependencies, use Shianmi via Mysten client setup

### DIFF
--- a/sui/typescript/backend_examples/package-lock.json
+++ b/sui/typescript/backend_examples/package-lock.json
@@ -5,8 +5,8 @@
   "packages": {
     "": {
       "dependencies": {
-        "@mysten/sui": "^1.18.0",
-        "@shinami/clients": "^0.9.4"
+        "@mysten/sui": "^1.19.0",
+        "@shinami/clients": "^0.9.5"
       },
       "devDependencies": {
         "typescript": "^5.6.3"
@@ -88,22 +88,22 @@
       }
     },
     "node_modules/@mysten/bcs": {
-      "version": "1.2.0",
-      "resolved": "https://registry.npmjs.org/@mysten/bcs/-/bcs-1.2.0.tgz",
-      "integrity": "sha512-LuKonrGdGW7dq/EM6U2L9/as7dFwnhZnsnINzB/vu08Xfrj0qzWwpLOiXagAa5yZOPLK7anRZydMonczFkUPzA==",
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/@mysten/bcs/-/bcs-1.2.1.tgz",
+      "integrity": "sha512-RMSaUsNb8oR0rTRVIOOcyoEVJqQi6DLvMXN+7mvDcki12FJFQ0lF89zQa7AV7cIurWlDQfJ8VIbCuRDyK+955A==",
       "license": "Apache-2.0",
       "dependencies": {
         "bs58": "^6.0.0"
       }
     },
     "node_modules/@mysten/sui": {
-      "version": "1.18.0",
-      "resolved": "https://registry.npmjs.org/@mysten/sui/-/sui-1.18.0.tgz",
-      "integrity": "sha512-cFh5LxXZrXb/ZAD1dkKeQxzhgRYFXreyFGmI7w/JQWwdl+/0FrHJBwaWyTmGxJ/6ZC9SlaOPOk63flN7DbUurg==",
+      "version": "1.19.0",
+      "resolved": "https://registry.npmjs.org/@mysten/sui/-/sui-1.19.0.tgz",
+      "integrity": "sha512-hjNCArz7upZaGZNNmMeQRKSlQK73eN+p8MlKJvlZpx/6gorK0WWFWWjEcIyJndkIDbLb06nbQbWIWZ8KoI036Q==",
       "license": "Apache-2.0",
       "dependencies": {
         "@graphql-typed-document-node/core": "^3.2.0",
-        "@mysten/bcs": "1.2.0",
+        "@mysten/bcs": "1.2.1",
         "@noble/curves": "^1.4.2",
         "@noble/hashes": "^1.4.0",
         "@scure/bip32": "^1.4.0",
@@ -200,9 +200,9 @@
       }
     },
     "node_modules/@shinami/clients": {
-      "version": "0.9.4",
-      "resolved": "https://registry.npmjs.org/@shinami/clients/-/clients-0.9.4.tgz",
-      "integrity": "sha512-25GmWltqqRcQxD+fxlMoPXEvWEmI/jFjaVGbO3hOpBtkgsPNXMBZWaFnLiW45MVwc1fRulv8eOh/lYgu7VX5XQ==",
+      "version": "0.9.5",
+      "resolved": "https://registry.npmjs.org/@shinami/clients/-/clients-0.9.5.tgz",
+      "integrity": "sha512-5MBFHa/u4HAtI6nXgva3O+NWeGpKR/OJDDEybjbmqSJ+8rBeuJfWR7lqhQ9R20aMPrQNRVlj+u0me2qh5FgPtw==",
       "license": "Apache-2.0",
       "dependencies": {
         "@open-rpc/client-js": "^1.8.1",

--- a/sui/typescript/backend_examples/package.json
+++ b/sui/typescript/backend_examples/package.json
@@ -3,8 +3,8 @@
     "typescript": "^5.6.3"
   },
   "dependencies": {
-    "@mysten/sui": "^1.18.0",
-    "@shinami/clients": "^0.9.4"
+    "@mysten/sui": "^1.19.0",
+    "@shinami/clients": "^0.9.5"
   },
   "type": "module"
 }

--- a/sui/typescript/dapp_kit_example/.env
+++ b/sui/typescript/dapp_kit_example/.env
@@ -2,3 +2,4 @@
 EXAMPLE_MOVE_PACKAGE_ID = '0xd8f042479dcb0028d868051bd53f0d3a41c600db7b14241674db1c2e60124975'
 # USER123_WALLET_ID = 'Static wallet id for one specific user. In a real app you would look up the walletId for a given userId'
 # USER123_WALLET_SECRET = 'Static wallet secret for one specific walletId.'
+# VITE_SHINAMI_PUBLIC_TESTNET_NODE_URL_AND_API_KEY = "https://api.shinami.com/sui/node/v1/ACCESS_KEY - this is a publicly visible key"

--- a/sui/typescript/dapp_kit_example/package-lock.json
+++ b/sui/typescript/dapp_kit_example/package-lock.json
@@ -8,10 +8,10 @@
       "name": "shinami-plus-dapp-kit-example",
       "version": "0.1.0",
       "dependencies": {
-        "@mysten/dapp-kit": "^0.14.20",
-        "@mysten/sui": "^1.9.0",
+        "@mysten/dapp-kit": "^0.14.46",
+        "@mysten/sui": "^1.19.0",
         "@radix-ui/themes": "^3.1.3",
-        "@shinami/clients": "^0.9.3",
+        "@shinami/clients": "^0.9.5",
         "@tanstack/react-query": "^5.56.2",
         "axios": "^1.7.7",
         "dotenv-flow": "^4.1.0",
@@ -918,23 +918,23 @@
       }
     },
     "node_modules/@mysten/bcs": {
-      "version": "1.0.4",
-      "resolved": "https://registry.npmjs.org/@mysten/bcs/-/bcs-1.0.4.tgz",
-      "integrity": "sha512-6JoQi59GN/dVEBCNq8Rj4uOR0niDrJqDx/2gNQWXANwJakHIGH0AMniHrXP41B2dF+mZ3HVmh9Hi3otiEVQTrQ==",
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/@mysten/bcs/-/bcs-1.2.1.tgz",
+      "integrity": "sha512-RMSaUsNb8oR0rTRVIOOcyoEVJqQi6DLvMXN+7mvDcki12FJFQ0lF89zQa7AV7cIurWlDQfJ8VIbCuRDyK+955A==",
       "license": "Apache-2.0",
       "dependencies": {
         "bs58": "^6.0.0"
       }
     },
     "node_modules/@mysten/dapp-kit": {
-      "version": "0.14.20",
-      "resolved": "https://registry.npmjs.org/@mysten/dapp-kit/-/dapp-kit-0.14.20.tgz",
-      "integrity": "sha512-dsgYRL/XS3jaiViI/Jl54p2T2ezF0ehDA4+77P+iB3hsWhMsOtqdiSVabGWIMO+dlGpD6hy9g+oVCR/jlWsFRg==",
+      "version": "0.14.46",
+      "resolved": "https://registry.npmjs.org/@mysten/dapp-kit/-/dapp-kit-0.14.46.tgz",
+      "integrity": "sha512-NDnEiKXSxe1bsjvzxIKFdGTdINzj3fMdOPRasdA/m2UTxOyKHmMw+ECvpfBHLbAeZ3Tsw7KReL8Jz/A8fo0ohg==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@mysten/sui": "1.9.0",
-        "@mysten/wallet-standard": "0.13.4",
-        "@mysten/zksend": "0.11.2",
+        "@mysten/sui": "1.19.0",
+        "@mysten/wallet-standard": "0.13.22",
+        "@mysten/zksend": "0.12.12",
         "@radix-ui/react-dialog": "^1.1.1",
         "@radix-ui/react-dropdown-menu": "^2.1.1",
         "@radix-ui/react-slot": "^1.1.0",
@@ -950,22 +950,24 @@
       }
     },
     "node_modules/@mysten/sui": {
-      "version": "1.9.0",
-      "resolved": "https://registry.npmjs.org/@mysten/sui/-/sui-1.9.0.tgz",
-      "integrity": "sha512-AcnwVK7ro8+GWAp/vz0V35naS1/PD1FkYlH6rglupKWvVIpnmEBgjr+XE7U4LvtAyoXPiE4uj/MhXLIx5rZuzw==",
+      "version": "1.19.0",
+      "resolved": "https://registry.npmjs.org/@mysten/sui/-/sui-1.19.0.tgz",
+      "integrity": "sha512-hjNCArz7upZaGZNNmMeQRKSlQK73eN+p8MlKJvlZpx/6gorK0WWFWWjEcIyJndkIDbLb06nbQbWIWZ8KoI036Q==",
       "license": "Apache-2.0",
       "dependencies": {
         "@graphql-typed-document-node/core": "^3.2.0",
-        "@mysten/bcs": "1.0.4",
+        "@mysten/bcs": "1.2.1",
         "@noble/curves": "^1.4.2",
         "@noble/hashes": "^1.4.0",
         "@scure/bip32": "^1.4.0",
         "@scure/bip39": "^1.3.0",
+        "@simplewebauthn/typescript-types": "^7.4.0",
         "@suchipi/femver": "^1.0.0",
         "bech32": "^2.0.0",
         "gql.tada": "^1.8.2",
         "graphql": "^16.9.0",
-        "tweetnacl": "^1.0.3",
+        "jose": "^5.6.3",
+        "poseidon-lite": "^0.2.0",
         "valibot": "^0.36.0"
       },
       "engines": {
@@ -973,23 +975,23 @@
       }
     },
     "node_modules/@mysten/wallet-standard": {
-      "version": "0.13.4",
-      "resolved": "https://registry.npmjs.org/@mysten/wallet-standard/-/wallet-standard-0.13.4.tgz",
-      "integrity": "sha512-uVN/6BJLhharDCiCCaB4uJ+cVRLMyHDU/QbZwL1agSwb+NX4/lDSaVso2DjQClpgcrR4fiBVfQsE9sIYPIDrbQ==",
+      "version": "0.13.22",
+      "resolved": "https://registry.npmjs.org/@mysten/wallet-standard/-/wallet-standard-0.13.22.tgz",
+      "integrity": "sha512-pMGY5BkZzEGcSH0qDxjbk/KKg8jIr7MLvSBg/YHLrfUC3WPOUwrSVjmjuGaSPEa/QI3Kj3mzwx9OH9C7OYW94A==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@mysten/sui": "1.9.0",
-        "@wallet-standard/core": "1.0.3"
+        "@mysten/sui": "1.19.0",
+        "@wallet-standard/core": "1.1.0"
       }
     },
     "node_modules/@mysten/zksend": {
-      "version": "0.11.2",
-      "resolved": "https://registry.npmjs.org/@mysten/zksend/-/zksend-0.11.2.tgz",
-      "integrity": "sha512-At1uLSk6aUeQVLCmDA6py9+5bvjuc5dUJJC+1DYnyooPkoO8VBQ5crODpZDss9Qr+RVzVZpD+zypCX5ovM4ZVg==",
+      "version": "0.12.12",
+      "resolved": "https://registry.npmjs.org/@mysten/zksend/-/zksend-0.12.12.tgz",
+      "integrity": "sha512-h7B4fCxpN1iK6pUNuz0x9rGzU6k4uQbfb/+6uJsV0kGRLN2cbS4wdFTPD+6g4xPrf94N0fHt2C+mlYOBfvGJ6g==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@mysten/sui": "1.9.0",
-        "@mysten/wallet-standard": "0.13.4",
+        "@mysten/sui": "1.19.0",
+        "@mysten/wallet-standard": "0.13.22",
         "mitt": "^3.0.1",
         "nanostores": "^0.10.3",
         "valibot": "^0.36.0"
@@ -2584,9 +2586,9 @@
       }
     },
     "node_modules/@shinami/clients": {
-      "version": "0.9.3",
-      "resolved": "https://registry.npmjs.org/@shinami/clients/-/clients-0.9.3.tgz",
-      "integrity": "sha512-6Dt75rm2GJSEqhg8pGgG2MRI/+P6GsXk/XTKJgejdKT8OxgEr+SN/lQewHxyzai58FVN3J1ErVGNeiSASxQRiw==",
+      "version": "0.9.5",
+      "resolved": "https://registry.npmjs.org/@shinami/clients/-/clients-0.9.5.tgz",
+      "integrity": "sha512-5MBFHa/u4HAtI6nXgva3O+NWeGpKR/OJDDEybjbmqSJ+8rBeuJfWR7lqhQ9R20aMPrQNRVlj+u0me2qh5FgPtw==",
       "license": "Apache-2.0",
       "dependencies": {
         "@open-rpc/client-js": "^1.8.1",
@@ -2607,6 +2609,13 @@
           "optional": true
         }
       }
+    },
+    "node_modules/@simplewebauthn/typescript-types": {
+      "version": "7.4.0",
+      "resolved": "https://registry.npmjs.org/@simplewebauthn/typescript-types/-/typescript-types-7.4.0.tgz",
+      "integrity": "sha512-8/ZjHeUPe210Bt5oyaOIGx4h8lHdsQs19BiOT44gi/jBEgK7uBGA0Fy7NRsyh777al3m6WM0mBf0UR7xd4R7WQ==",
+      "deprecated": "This package has been renamed to @simplewebauthn/types. Please install @simplewebauthn/types instead to ensure you receive future updates.",
+      "license": "MIT"
     },
     "node_modules/@suchipi/femver": {
       "version": "1.0.0",
@@ -2892,60 +2901,89 @@
       }
     },
     "node_modules/@wallet-standard/app": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/@wallet-standard/app/-/app-1.0.1.tgz",
-      "integrity": "sha512-LnLYq2Vy2guTZ8GQKKSXQK3+FRGPil75XEdkZqE6fiLixJhZJoJa5hT7lXxwe0ykVTt9LEThdTbOpT7KadS26Q==",
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/@wallet-standard/app/-/app-1.1.0.tgz",
+      "integrity": "sha512-3CijvrO9utx598kjr45hTbbeeykQrQfKmSnxeWOgU25TOEpvcipD/bYDQWIqUv1Oc6KK4YStokSMu/FBNecGUQ==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@wallet-standard/base": "^1.0.1"
+        "@wallet-standard/base": "^1.1.0"
       },
       "engines": {
         "node": ">=16"
       }
     },
     "node_modules/@wallet-standard/base": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/@wallet-standard/base/-/base-1.0.1.tgz",
-      "integrity": "sha512-1To3ekMfzhYxe0Yhkpri+Fedq0SYcfrOfJi3vbLjMwF2qiKPjTGLwZkf2C9ftdQmxES+hmxhBzTwF4KgcOwf8w==",
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/@wallet-standard/base/-/base-1.1.0.tgz",
+      "integrity": "sha512-DJDQhjKmSNVLKWItoKThJS+CsJQjR9AOBOirBVT1F9YpRyC9oYHE+ZnSf8y8bxUphtKqdQMPVQ2mHohYdRvDVQ==",
       "license": "Apache-2.0",
       "engines": {
         "node": ">=16"
       }
     },
     "node_modules/@wallet-standard/core": {
-      "version": "1.0.3",
-      "resolved": "https://registry.npmjs.org/@wallet-standard/core/-/core-1.0.3.tgz",
-      "integrity": "sha512-Jb33IIjC1wM1HoKkYD7xQ6d6PZ8EmMZvyc8R7dFgX66n/xkvksVTW04g9yLvQXrLFbcIjHrCxW6TXMhvpsAAzg==",
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/@wallet-standard/core/-/core-1.1.0.tgz",
+      "integrity": "sha512-v2W5q/NlX1qkn2q/JOXQT//pOAdrhz7+nOcO2uiH9+a0uvreL+sdWWqkhFmMcX+HEBjaibdOQMUoIfDhOGX4XA==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@wallet-standard/app": "^1.0.1",
-        "@wallet-standard/base": "^1.0.1",
-        "@wallet-standard/features": "^1.0.3",
-        "@wallet-standard/wallet": "^1.0.1"
+        "@wallet-standard/app": "^1.1.0",
+        "@wallet-standard/base": "^1.1.0",
+        "@wallet-standard/errors": "^0.1.0",
+        "@wallet-standard/features": "^1.1.0",
+        "@wallet-standard/wallet": "^1.1.0"
       },
       "engines": {
         "node": ">=16"
       }
     },
-    "node_modules/@wallet-standard/features": {
-      "version": "1.0.3",
-      "resolved": "https://registry.npmjs.org/@wallet-standard/features/-/features-1.0.3.tgz",
-      "integrity": "sha512-m8475I6W5LTatTZuUz5JJNK42wFRgkJTB0I9tkruMwfqBF2UN2eomkYNVf9RbrsROelCRzSFmugqjKZBFaubsA==",
+    "node_modules/@wallet-standard/errors": {
+      "version": "0.1.0",
+      "resolved": "https://registry.npmjs.org/@wallet-standard/errors/-/errors-0.1.0.tgz",
+      "integrity": "sha512-ag0eq5ixy7rz8M5YUWGi/EoIJ69KJ+KILFNunoufgmXVkiISC7+NIZXJYTJrapni4f9twE1hfT+8+IV2CYCvmg==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@wallet-standard/base": "^1.0.1"
+        "chalk": "^5.3.0",
+        "commander": "^12.1.0"
+      },
+      "bin": {
+        "errors": "bin/cli.mjs"
+      },
+      "engines": {
+        "node": ">=16"
+      }
+    },
+    "node_modules/@wallet-standard/errors/node_modules/chalk": {
+      "version": "5.4.1",
+      "resolved": "https://registry.npmjs.org/chalk/-/chalk-5.4.1.tgz",
+      "integrity": "sha512-zgVZuo2WcZgfUEmsn6eO3kINexW8RAE4maiQ8QNs8CtpPCSyMiYsULR3HQYkm3w8FIA3SberyMJMSldGsW+U3w==",
+      "license": "MIT",
+      "engines": {
+        "node": "^12.17.0 || ^14.13 || >=16.0.0"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/chalk?sponsor=1"
+      }
+    },
+    "node_modules/@wallet-standard/features": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/@wallet-standard/features/-/features-1.1.0.tgz",
+      "integrity": "sha512-hiEivWNztx73s+7iLxsuD1sOJ28xtRix58W7Xnz4XzzA/pF0+aicnWgjOdA10doVDEDZdUuZCIIqG96SFNlDUg==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@wallet-standard/base": "^1.1.0"
       },
       "engines": {
         "node": ">=16"
       }
     },
     "node_modules/@wallet-standard/wallet": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/@wallet-standard/wallet/-/wallet-1.0.1.tgz",
-      "integrity": "sha512-qkhJeuQU2afQTZ02yMZE5SFc91Fo3hyFjFkpQglHudENNyiSG0oUKcIjky8X32xVSaumgTZSQUAzpXnCTWHzKQ==",
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/@wallet-standard/wallet/-/wallet-1.1.0.tgz",
+      "integrity": "sha512-Gt8TnSlDZpAl+RWOOAB/kuvC7RpcdWAlFbHNoi4gsXsfaWa1QCT6LBcfIYTPdOZC9OVZUDwqGuGAcqZejDmHjg==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@wallet-standard/base": "^1.0.1"
+        "@wallet-standard/base": "^1.1.0"
       },
       "engines": {
         "node": ">=16"
@@ -3294,6 +3332,15 @@
       },
       "engines": {
         "node": ">= 0.8"
+      }
+    },
+    "node_modules/commander": {
+      "version": "12.1.0",
+      "resolved": "https://registry.npmjs.org/commander/-/commander-12.1.0.tgz",
+      "integrity": "sha512-Vw8qHK3bZM9y/P10u3Vib8o/DdkvA2OtPtZvD871QKjy74Wj1WSKFILMPRPSdUSx5RFK1arlJzEtA4PkFgnbuA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
       }
     },
     "node_modules/concat-map": {
@@ -4088,6 +4135,15 @@
         "ws": "*"
       }
     },
+    "node_modules/jose": {
+      "version": "5.9.6",
+      "resolved": "https://registry.npmjs.org/jose/-/jose-5.9.6.tgz",
+      "integrity": "sha512-AMlnetc9+CV9asI19zHmrgS/WYsWUwCn2R7RzlbJWD7F9eWYUTGyBmU9o6PxngtLGOiDGPRu+Uc4fhKzbpteZQ==",
+      "license": "MIT",
+      "funding": {
+        "url": "https://github.com/sponsors/panva"
+      }
+    },
     "node_modules/js-tokens": {
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/js-tokens/-/js-tokens-4.0.0.tgz",
@@ -4422,6 +4478,12 @@
       "funding": {
         "url": "https://github.com/sponsors/jonschlinkert"
       }
+    },
+    "node_modules/poseidon-lite": {
+      "version": "0.2.1",
+      "resolved": "https://registry.npmjs.org/poseidon-lite/-/poseidon-lite-0.2.1.tgz",
+      "integrity": "sha512-xIr+G6HeYfOhCuswdqcFpSX47SPhm0EpisWJ6h7fHlWwaVIvH3dLnejpatrtw6Xc6HaLrpq05y7VRfvDmDGIog==",
+      "license": "MIT"
     },
     "node_modules/postcss": {
       "version": "8.4.45",
@@ -4986,12 +5048,6 @@
       "optionalDependencies": {
         "fsevents": "~2.3.3"
       }
-    },
-    "node_modules/tweetnacl": {
-      "version": "1.0.3",
-      "resolved": "https://registry.npmjs.org/tweetnacl/-/tweetnacl-1.0.3.tgz",
-      "integrity": "sha512-6rt+RN7aOi1nGMyC4Xa5DdYiukl2UWCbcJft7YhxReBGQD7OAM8Pbxw6YMo4r2diNEA8FEmu32YOn9rhaiE5yw==",
-      "license": "Unlicense"
     },
     "node_modules/type-is": {
       "version": "1.6.18",

--- a/sui/typescript/dapp_kit_example/package.json
+++ b/sui/typescript/dapp_kit_example/package.json
@@ -9,10 +9,10 @@
     "build": "vite build"
   },
   "dependencies": {
-    "@mysten/dapp-kit": "^0.14.20",
-    "@mysten/sui": "^1.9.0",
+    "@mysten/dapp-kit": "^0.14.46",
+    "@mysten/sui": "^1.19.0",
     "@radix-ui/themes": "^3.1.3",
-    "@shinami/clients": "^0.9.3",
+    "@shinami/clients": "^0.9.5",
     "@tanstack/react-query": "^5.56.2",
     "axios": "^1.7.7",
     "dotenv-flow": "^4.1.0",

--- a/sui/typescript/dapp_kit_example/src/client/App.tsx
+++ b/sui/typescript/dapp_kit_example/src/client/App.tsx
@@ -10,7 +10,6 @@ import { Box, Flex, Heading } from "@radix-ui/themes";
 import axios from 'axios';
 import { SuiTransactionBlockResponse } from "@mysten/sui/client";
 
-
 function App() {
   const currentAccount = useCurrentAccount();
   const { mutateAsync: signTransaction } = useSignTransaction();

--- a/sui/typescript/dapp_kit_example/src/client/networkConfig.ts
+++ b/sui/typescript/dapp_kit_example/src/client/networkConfig.ts
@@ -4,10 +4,10 @@ import { createNetworkConfig } from "@mysten/dapp-kit";
 const { networkConfig } =
   createNetworkConfig({
     testnet: {
-      url: getFullnodeUrl("testnet")
+      url: import.meta.env.VITE_SHINAMI_PUBLIC_TESTNET_NODE_URL_AND_API_KEY || getFullnodeUrl('testnet'),
     },
     mainnet: {
-      url: getFullnodeUrl("mainnet")
+      url: getFullnodeUrl('mainnet'),
     }
   });
 


### PR DESCRIPTION
This does two main things:
1. Bumps the Shinami and Mysten SDK versions to the latest for our sample code. I tested most functions after making the change.
2. Updates the creation and use of a Shinami client in the dapp-kit example to mimic what I saw from a customer.